### PR TITLE
Fixed a typo and removed empty README.md

### DIFF
--- a/src/r3/atomic-swap/corda/README.md
+++ b/src/r3/atomic-swap/corda/README.md
@@ -66,7 +66,7 @@ if you have manually prepared the EVM test environment.
 
 #### Deploy
 
-Plain and Dockerized deploymet is under development
+Plain and Dockerized deployment is under development
 
 ### Testing
 


### PR DESCRIPTION
Fixed a typo in atomic-swap/corda/README.md and removed empty atomic-swap/README.md