### PR TITLE
Recursion

### DIFF
--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/BranchNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/BranchNode.kt
@@ -34,6 +34,9 @@ class BranchNode(private val branches: Array<Node>, private val value: ByteArray
     companion object {
         private val emptyArray = ByteArray(0)
 
+        fun from(vararg sparseBranches: Pair<Int, Node>): BranchNode = from(sparseBranches.toList())
+        fun from(vararg sparseBranches: Pair<Int, Node>, value: ByteArray): BranchNode =
+            from(sparseBranches.toList(), value)
         fun from(sparseBranches: List<Pair<Int, Node>>): BranchNode = from(sparseBranches, emptyArray)
 
         fun from(sparseBranches: List<Pair<Int, Node>>, value: ByteArray): BranchNode {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/BranchNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/BranchNode.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.r3.corda.interop.evm.common.trie
+
+import org.web3j.rlp.RlpEncoder
+import org.web3j.rlp.RlpList
+import org.web3j.rlp.RlpString
+
+/**
+ * Represents a BranchNode in a Patricia Trie.
+ *
+ * A BranchNode consists of an array of Node branches and a value.
+ * The encoded form is an RLP (Recursive Length Prefix) encoded list of the branches and value.
+ *
+ * @property branches The array of Nodes that the BranchNode contains.
+ * @property value The value of the BranchNode.
+ */
+class BranchNode(
+    private val branches: Array<Node>,
+    private val value: ByteArray
+) : Node {
+
+    /**
+     * The RLP-encoded form of the BranchNode, which is an RLP-encoded list of the branches and value.
+     */
+    override val encoded: ByteArray
+        get() {
+            return RlpEncoder.encode(RlpList(branches.map { node ->
+                val encodedNode = node.encoded
+                when {
+                    node is EmptyNode -> RlpString.create(ByteArray(0))
+                    // NOTE: in the next line, if node can be a HashNode then we need to call
+                    // node.hash otherwise we can optimize and call Hash.sha3(encodedNode)
+                    encodedNode.size >= 32 -> RlpString.create(node.hash)
+                    else -> RlpString.create(encodedNode)
+                }
+            }.plus(RlpString.create(value))))
+        }
+
+    private fun getBranch(branch: Byte): Node = branches[branch.toInt()]
+
+    override fun put(key: NibbleArray, newValue: ByteArray): Node =
+        if (key.isEmpty()) Node.branch(branches, newValue)
+        else {
+            val newBranches = Array(16) { index ->
+                if (index == key.head.toInt()) getBranch(key.head).put(key.tail, newValue) else branches[index]
+            }
+            Node.branch(newBranches, value)
+        }
+
+    override fun get(key: NibbleArray): ByteArray = if (key.isEmpty()) value else getBranch(key.head).get(key.tail)
+
+    override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
+            store.put(hash, encoded)
+
+            if (key.isEmpty()) {
+                require(value.isNotEmpty()) { "Terminal branch without value" }
+                return store
+            }
+
+            return getBranch(key.head).generateMerkleProof(key.tail, store)
+        }
+
+    override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
+        if (key.isEmpty()) {
+            value.contentEquals(expectedValue)
+        } else {
+            Node.verifyMerkleProof(getBranch(key.head).hash, key.tail, expectedValue, proof)
+        }
+}

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/EmptyNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/EmptyNode.kt
@@ -33,7 +33,7 @@ object EmptyNode : Node {
     override val encoded: ByteArray
         get() = RlpEncoder.encode(RlpString.create(ByteArray(0)))
 
-    override fun put(key: NibbleArray, newValue: ByteArray): Node = Node.leaf(key, newValue)
+    override fun put(key: NibbleArray, newValue: ByteArray): Node = LeafNode(key, newValue)
 
     override fun get(key: NibbleArray): ByteArray = ByteArray(0)
 

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/EmptyNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/EmptyNode.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.r3.corda.interop.evm.common.trie
+
+import org.web3j.rlp.RlpEncoder
+import org.web3j.rlp.RlpString
+
+/**
+ * Represents an EmptyNode in a Patricia Trie.
+ *
+ * This class is a specific type of Node, with its encoded form
+ * being the RLP (Recursive Length Prefix) encoding of an empty byte array.
+ */
+object EmptyNode : Node {
+    /**
+     * Returns the RLP-encoded form of the EmptyNode,
+     * which is an empty byte array encoded in RLP.
+     */
+    override val encoded: ByteArray
+        get() = RlpEncoder.encode(RlpString.create(ByteArray(0)))
+
+    override fun put(key: NibbleArray, newValue: ByteArray): Node = Node.leaf(key, newValue)
+
+    override fun get(key: NibbleArray): ByteArray = ByteArray(0)
+
+    override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
+        throw IllegalArgumentException("Key is not part of the trie")
+    }
+
+    override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean {
+        throw IllegalArgumentException("Key is not part of the trie")
+    }
+}

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/ExtensionNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/ExtensionNode.kt
@@ -106,15 +106,7 @@ class ExtensionNode(
             }
 
     override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
-        if (key.startsWith(path)) {
-            Node.verifyMerkleProof(
-                innerNode.hash,
-                key.dropFirst(path.size),
-                expectedValue,
-                proof
-            )
-        } else {
-            throw IllegalArgumentException("Key is not part of the trie")
-        }
+        if (key.startsWith(path)) Node.verifyMerkleProof(innerNode.hash, key.dropFirst(path.size), expectedValue, proof)
+        else throw IllegalArgumentException("Key is not part of the trie")
 
 }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/ExtensionNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/ExtensionNode.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.r3.corda.interop.evm.common.trie
+
+import org.web3j.rlp.RlpDecoder
+import org.web3j.rlp.RlpEncoder
+import org.web3j.rlp.RlpList
+import org.web3j.rlp.RlpString
+
+/**
+ * Represents an ExtensionNode in a Patricia Trie.
+ *
+ * An ExtensionNode consists of a path and an inner node.
+ * The encoded form is an RLP (Recursive Length Prefix) encoded list of the path and the inner node.
+ *
+ * @property path The path of the ExtensionNode, stored as a nibbles array.
+ * @property innerNode The inner Node that the ExtensionNode points to.
+ */
+class ExtensionNode(
+    private val path: NibbleArray,
+    private val innerNode: Node
+) : Node {
+
+    /**
+     * The RLP-encoded form of the ExtensionNode, which is an RLP-encoded list of the path and the inner node.
+     */
+    override val encoded: ByteArray
+        get() {
+            val encodedInnerNode = innerNode.encoded
+            return RlpEncoder.encode(
+                RlpList(
+                    RlpString.create(PatriciaTriePathType.EXTENSION.applyPrefix(path).toBytes()),
+                    if (encodedInnerNode.size >= 32) {
+                        RlpString.create(innerNode.hash)
+                    } else {
+                        RlpDecoder.decode(encodedInnerNode) // TODO: review
+                    }
+                )
+            )
+        }
+
+    override fun put(key: NibbleArray, newValue: ByteArray): Node {
+        val matchingLength = path.prefixMatchingLength(key)
+
+        // Key (1, 2, 3...) contains entire path (1, 2, 3)
+        if (matchingLength == path.size) {
+            // Put the value into the inner node, at the remaining key
+            return Node.extension(path, innerNode.put(key.dropFirst(matchingLength), newValue))
+        }
+
+        // Key (1, 2, 3...) contains part of path (1, 2, 4, 5, 6)
+        val matchingPath = path.takeFirst(matchingLength)       // Nibbles where key and path agree (1, 2)
+        val pathIndex = path[matchingLength].toInt()            // Nibble where key and path diverge (4)
+        val remainingPath = path.remainingAfter(matchingLength) // Path nibbles after divergence (5, 6)
+
+        // Branch either to the inner node or to an extension terminating in the inner node
+        val firstBranch = if (remainingPath.isEmpty()) innerNode else Node.extension(remainingPath, innerNode)
+
+        val branchNode = if (matchingLength == key.size) {
+            // Path (1, 2, 3...) contains entire key (1, 2, 3)
+
+            // 3 -> firstBranch
+            Node.branch(listOf(pathIndex to firstBranch), newValue)
+        } else {
+            // Path (1, 2, 3...) contains part of key (1, 2, 4, 5, 6)
+            val keyIndex = key[matchingLength].toInt()            // Nibble where key and path diverge (4)
+            val remainingKey = key.remainingAfter(matchingLength) // Key nibbles after divergence (5, 6)
+
+            // 3 -> firstBranch
+            // 4 -> leaf((5, 6), newValue)
+            Node.branch(listOf(pathIndex to firstBranch, keyIndex to Node.leaf(remainingKey, newValue)))
+        }
+
+        return if (matchingPath.isEmpty()) branchNode else Node.extension(matchingPath, branchNode)
+    }
+
+    override fun get(key: NibbleArray): ByteArray {
+        val matchingLength = path.prefixMatchingLength(key)
+        if (matchingLength < path.size) {
+            return ByteArray(0) // TODO: key not found
+        }
+
+        return innerNode.get(key.dropFirst(matchingLength))
+    }
+
+    override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore =
+            if (key.startsWith(path)) {
+                store.put(hash, encoded)
+                innerNode.generateMerkleProof(key.dropFirst(path.size), store)
+            } else {
+                throw IllegalArgumentException("Key is not part of the trie")
+            }
+
+    override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
+        if (key.startsWith(path)) {
+            Node.verifyMerkleProof(
+                innerNode.hash,
+                key.dropFirst(path.size),
+                expectedValue,
+                proof
+            )
+        } else {
+            throw IllegalArgumentException("Key is not part of the trie")
+        }
+
+}

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/HashNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/HashNode.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.r3.corda.interop.evm.common.trie
+
+/**
+ * A representation of a node in a Patricia Trie that is used to store a hash and an inner node.
+ * This class provides methods to create a new HashNode and retrieve its encoded representation.
+ *
+ * @param hash The hash of the node
+ * @param innerNode The inner node associated with this HashNode. Defaults to an EmptyNode if not provided.
+ */
+class HashNode(override val hash: ByteArray, private val innerNode: Node) : Node {
+    /**
+     * Returns the encoded representation of the HashNode. If the inner node is an EmptyNode,
+     * it returns the hash of the node, otherwise it returns the encoded representation of the inner node.
+     */
+    override val encoded: ByteArray get() = if (innerNode is EmptyNode) hash else innerNode.encoded
+
+    override fun put(key: NibbleArray, newValue: ByteArray): Node {
+        throw UnsupportedOperationException("Cannot put into HashNode")
+    }
+
+    override fun get(key: NibbleArray): ByteArray {
+        throw UnsupportedOperationException("Cannot get from HashNode")
+    }
+
+    override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
+        throw UnsupportedOperationException("Cannot generate Merkle proof from HashNode")
+    }
+
+    override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean {
+        throw UnsupportedOperationException("Cannot verify Merkle proof from HashNode")
+    }
+}

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/KeyValueStore.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/KeyValueStore.kt
@@ -38,6 +38,7 @@ interface KeyValueStore {
      * @return True if the store is empty, false otherwise.
      */
     fun isEmpty(): Boolean
+
 }
 
 interface WriteableKeyValueStore : KeyValueStore {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/KeyValueStore.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/KeyValueStore.kt
@@ -39,6 +39,9 @@ interface KeyValueStore {
      */
     fun isEmpty(): Boolean
 
+    fun verify(rootHash: ByteArray, key: NibbleArray, expectedValue: ByteArray): Boolean =
+        Node.createFromRLP(get(rootHash) ?: throw IllegalArgumentException("Proof is invalid"))
+            .verifyMerkleProof(key, expectedValue, this)
 }
 
 interface WriteableKeyValueStore : KeyValueStore {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/LeafNode.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/LeafNode.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.r3.corda.interop.evm.common.trie
+
+import org.web3j.rlp.RlpEncoder
+import org.web3j.rlp.RlpList
+import org.web3j.rlp.RlpString
+
+/**
+ * Represents a LeafNode in a Patricia Trie.
+ *
+ * A LeafNode consists of a path (represented as a nibble array) and a value (represented as a byte array).
+ * The encoded form is an RLP (Recursive Length Prefix) encoded list of the path and value.
+ *
+ * @property path The path of the node, represented as a nibble array.
+ * @property value The value of the node, represented as a byte array.
+ */
+class LeafNode(
+    private val path: NibbleArray,
+    val value: ByteArray
+) : Node {
+
+    /**
+     * The RLP-encoded form of the LeafNode, which is an RLP-encoded list of the path and value.
+     */
+    override val encoded: ByteArray
+        get() {
+            return RlpEncoder.encode(
+                RlpList(
+                    RlpString.create(PatriciaTriePathType.LEAF.applyPrefix(path).toBytes()),
+                    RlpString.create(value)
+                )
+            )
+        }
+
+    override fun put(key: NibbleArray, newValue: ByteArray): Node {
+        // Overwrite value if key and path match exactly
+        if (path == key) return Node.leaf(key, newValue)
+
+        val matchingLength = path.prefixMatchingLength(key)
+
+        val branches = mutableListOf<Pair<Int, Node>>()
+
+        // If there's some path (1, 2, 3, 4) left after the match (1, 2) with key (1, 2, 5, 6)
+        if (matchingLength < path.size) {
+            // Put the current value in a branch: 3 -> leaf((4), value)
+            branches.add(path[matchingLength].toInt() to Node.leaf(path.remainingAfter(matchingLength), value))
+        }
+
+        // If there's some key (1, 2, 5, 6) left after the match (1, 2) with path (1, 2, 3, 4)
+        if (matchingLength < key.size) {
+            // Put the new value in a branch: 5 -> ((6), newValue)
+            branches.add(key[matchingLength].toInt() to Node.leaf(key.remainingAfter(matchingLength), newValue))
+        }
+
+        /*
+        Note implicit logic here:
+
+        * matchingLength is never more than path.size, and never more than key.size
+        * path.size and key.size are never equal, or we would have hit the exact match condition above.
+        * If matchingLength is path.size, it cannot be equal to key.size, so it must be less than key.size.
+        * If matchingLength is key.size, it cannot be equal to path.size, so it must be less than path.size
+
+         */
+        val branchNode = when (matchingLength) {
+            // Implicitly, matchingLength < key.size, so branch to newValue is in branches
+            path.size -> Node.branch(branches, value)
+            // Implicitly, matchingLength < path.size, so branch to value is in branches
+            key.size -> Node.branch(branches, newValue)
+            // MatchingLength < key.size && matchingLength < path.size, so both branches are present
+            else -> Node.branch(branches)
+        }
+
+        return if (matchingLength == 0) branchNode else Node.extension(path.takeFirst(matchingLength), branchNode)
+    }
+
+    override fun get(key: NibbleArray): ByteArray = if (key == path) value else ByteArray(0)
+
+    override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
+        if (path == key) {
+            store.put(hash, encoded)
+            return store
+        } else {
+            throw IllegalArgumentException("Key is not part of the trie")
+        }
+    }
+
+    override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
+        if (path == key) {
+            value.contentEquals(expectedValue)
+        } else {
+            throw IllegalArgumentException("Key is not part of the trie")
+        }
+}

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.r3.corda.interop.evm.common.trie
 
 /**
@@ -62,8 +78,6 @@ data class NibbleArray(val values: ByteArray) {
     val tail: NibbleArray get() = dropFirst(1)
 
     fun isEmpty(): Boolean = values.isEmpty()
-
-    fun isNotEmpty(): Boolean = values.isNotEmpty()
 
     fun startsWith(other: NibbleArray): Boolean {
         if (other.size > size) {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
@@ -47,6 +47,8 @@ data class NibbleArray(val values: ByteArray) {
     fun dropFirst(numberOfNibbles: Int): NibbleArray =
         NibbleArray(values.copyOfRange(numberOfNibbles, values.size))
 
+    fun remainingAfter(index: Int): NibbleArray = dropFirst(index + 1)
+
     fun takeFirst(numberOfNibbles: Int): NibbleArray =
         NibbleArray(values.copyOfRange(0, numberOfNibbles))
 

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/NibbleArray.kt
@@ -19,7 +19,7 @@ package com.r3.corda.interop.evm.common.trie
 /**
  * Represents an array of nibbles (values between 0-15 inclusive)
  */
-data class NibbleArray(val values: ByteArray) {
+class NibbleArray(private val values: ByteArray) {
 
     companion object {
         fun fromBytes(bytes: ByteArray): NibbleArray {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
@@ -91,25 +91,6 @@ interface Node {
         fun extension(path: NibbleArray, value: Node): ExtensionNode = ExtensionNode(path, value)
 
         /**
-         * Verifies the Merkle proof for a given key and expected value.
-         *
-         * @param rootHash The root hash of the trie.
-         * @param key The key for which to verify the proof.
-         * @param expectedValue The expected value for the key.
-         * @param proof The proof to verify.
-         * @return Boolean indicating whether the proof is valid.
-         */
-        fun verifyMerkleProof(
-            rootHash: ByteArray,
-            key: NibbleArray,
-            expectedValue: ByteArray,
-            proof: KeyValueStore
-        ): Boolean {
-            val node = createFromRLP(proof.get(rootHash) ?: throw IllegalArgumentException("Proof is invalid"))
-            return node.verifyMerkleProof(key, expectedValue, proof)
-        }
-
-        /**
          * Create a Node from a RLP encoded byte array.
          * @param encoded RLP encoded byte array.
          * @return Node created from the RLP encoded byte array.
@@ -160,6 +141,10 @@ interface Node {
                 else -> throw IllegalArgumentException("Invalid RLP encoding")
             }
         }
+
+        fun verifyMerkleProof(rootHash: ByteArray, key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
+            createFromRLP(proof.get(rootHash) ?: throw IllegalArgumentException("Proof is invalid"))
+                .verifyMerkleProof(key, expectedValue, proof)
     }
 
 }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
@@ -150,8 +150,10 @@ sealed class Node {
      */
     class ExtensionNode(
         val path: NibbleArray,
-        var innerNode: Node
+        val innerNode: Node
     ) : Node() {
+
+        fun withInnerNode(newInnerNode: Node): ExtensionNode = ExtensionNode(path, newInnerNode)
 
         /**
          * The RLP-encoded form of the ExtensionNode, which is an RLP-encoded list of the path and the inner node.
@@ -182,8 +184,8 @@ sealed class Node {
      * @property value The value of the BranchNode.
      */
     class BranchNode(
-        val branches: Array<Node>,
-        var value: ByteArray
+        private val branches: Array<Node>,
+        val value: ByteArray
     ) : Node() {
 
         /**
@@ -209,9 +211,18 @@ sealed class Node {
          * @param nibbleKey The index at which to set the branch.
          * @param node The node to set at the index.
          */
-        fun setBranch(nibbleKey: Byte, node: Node) {
-            branches[nibbleKey.toInt()] = node
+        fun withBranch(nibbleKey: Byte, node: Node): BranchNode {
+            val newBranches = Array(16) { index ->
+                if (index == nibbleKey.toInt()) node else branches[index]
+            }
+            return BranchNode(newBranches, value)
         }
+
+        fun withValue(newValue: ByteArray): BranchNode {
+            return BranchNode(branches, newValue)
+        }
+
+        fun getBranch(branch: Byte): Node = branches[branch.toInt()]
     }
 
     /**

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/Node.kt
@@ -18,35 +18,33 @@ package com.r3.corda.interop.evm.common.trie
 
 import org.web3j.crypto.Hash.sha3
 import org.web3j.rlp.*
-import org.web3j.utils.Numeric
 
 /**
  * The base class for all types of nodes in a Patricia Trie.
  */
-sealed class Node {
+interface Node {
     /**
      * Get the encoded version of this node.
      * @return encoded byte array of this node.
      */
-    abstract val encoded: ByteArray
+    val encoded: ByteArray
 
     /**
      * Get the SHA-3 hash of the encoded node.
      * @return hash of the encoded node.
      */
-    open val hash: ByteArray
+    val hash: ByteArray
         get() = sha3(encoded)
 
     /**
      * Puts a key-value pair into a node of the Patricia Trie.
      * If the node does not exist, a new LeafNode is created.
      *
-     * @param node The node where to put the key-value pair.
      * @param key The key to put.
-     * @param value The value to put.
+     * @param newValue The value to put.
      * @return The node where the key-value pair was put.
      */
-    abstract fun put(key: NibbleArray, newValue: ByteArray): Node
+    fun put(key: NibbleArray, newValue: ByteArray): Node
 
     /**
      * Gets the value for a given key from the Patricia Trie.
@@ -54,7 +52,7 @@ sealed class Node {
      * @param key The key for which to get the value.
      * @return The value associated with the key, or an empty ByteArray if the key does not exist.
      */
-    abstract fun get(key: NibbleArray): ByteArray
+    fun get(key: NibbleArray): ByteArray
 
     /**
      * Generates a Merkle proof for a given key.
@@ -63,23 +61,13 @@ sealed class Node {
      * @param store A simple Key-Value that will collect the trie proofs
      * @return Merkle proof as KeyValueStore.
      */
-    abstract fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore) : KeyValueStore
+    fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore) : KeyValueStore
 
-    abstract fun verifyMerkleProof(
+    fun verifyMerkleProof(
         key: NibbleArray,
         expectedValue: ByteArray,
         proof: KeyValueStore
     ): Boolean
-
-    /**
-     * Provide a String representation of the Node for debugging.
-     * @return String representation of the Node.
-     */
-    override fun toString(): String {
-        return "NodeType: ${javaClass.simpleName} " +
-                "Hash: ${Numeric.toHexString(hash)} " +
-                "Encoded: ${Numeric.toHexString(encoded)}"
-    }
 
     companion object {
 
@@ -88,9 +76,6 @@ sealed class Node {
 
         fun leaf(key: ByteArray, value: ByteArray): LeafNode = leaf(NibbleArray.fromBytes(key), value)
         fun leaf(key: NibbleArray, value: ByteArray): LeafNode = LeafNode(key, value)
-
-        fun branch(): BranchNode = branch(emptyArray)
-        fun branch(value: ByteArray) = branch(Array<Node>(16) { EmptyNode }, value)
 
         fun branch(sparseBranches: List<Pair<Int, Node>>): BranchNode = branch(sparseBranches, emptyArray)
         fun branch(sparseBranches: List<Pair<Int, Node>>, value: ByteArray): BranchNode {
@@ -101,7 +86,7 @@ sealed class Node {
             return branch(branches, value)
         }
 
-        private fun branch(branches: Array<Node>, value: ByteArray): BranchNode = BranchNode(branches, value)
+        fun branch(branches: Array<Node>, value: ByteArray): BranchNode = BranchNode(branches, value)
 
         fun extension(path: NibbleArray, value: Node): ExtensionNode = ExtensionNode(path, value)
 
@@ -177,309 +162,4 @@ sealed class Node {
         }
     }
 
-    /**
-     * Represents an EmptyNode in a Patricia Trie.
-     *
-     * This class is a specific type of Node, with its encoded form
-     * being the RLP (Recursive Length Prefix) encoding of an empty byte array.
-     */
-    object EmptyNode : Node() {
-        /**
-         * Returns the RLP-encoded form of the EmptyNode,
-         * which is an empty byte array encoded in RLP.
-         */
-        override val encoded: ByteArray
-            get() = RlpEncoder.encode(RlpString.create(ByteArray(0)))
-
-        override fun put(key: NibbleArray, newValue: ByteArray): Node = leaf(key, newValue)
-
-        override fun get(key: NibbleArray): ByteArray = ByteArray(0)
-
-        override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
-            throw IllegalArgumentException("Key is not part of the trie")
-        }
-
-        override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean {
-            throw IllegalArgumentException("Key is not part of the trie")
-        }
-    }
-
-    /**
-     * Represents an ExtensionNode in a Patricia Trie.
-     *
-     * An ExtensionNode consists of a path and an inner node.
-     * The encoded form is an RLP (Recursive Length Prefix) encoded list of the path and the inner node.
-     *
-     * @property path The path of the ExtensionNode, stored as a nibbles array.
-     * @property innerNode The inner Node that the ExtensionNode points to.
-     */
-    class ExtensionNode(
-        val path: NibbleArray,
-        val innerNode: Node
-    ) : Node() {
-
-        /**
-         * The RLP-encoded form of the ExtensionNode, which is an RLP-encoded list of the path and the inner node.
-         */
-        override val encoded: ByteArray
-            get() {
-                val encodedInnerNode = innerNode.encoded
-                return RlpEncoder.encode(
-                    RlpList(
-                        RlpString.create(PatriciaTriePathType.EXTENSION.applyPrefix(path).toBytes()),
-                        if (encodedInnerNode.size >= 32) {
-                            RlpString.create(innerNode.hash)
-                        } else {
-                            RlpDecoder.decode(encodedInnerNode) // TODO: review
-                        }
-                    )
-                )
-            }
-
-        override fun put(key: NibbleArray, newValue: ByteArray): Node {
-            val matchingLength = path.prefixMatchingLength(key)
-
-            // Key (1, 2, 3...) contains entire path (1, 2, 3)
-            if (matchingLength == path.size) {
-                // Put the value into the inner node, at the remaining key
-                return extension(path, innerNode.put(key.dropFirst(matchingLength), newValue))
-            }
-
-            // Key (1, 2, 3...) contains part of path (1, 2, 4, 5, 6)
-            val matchingPath = path.takeFirst(matchingLength)       // Nibbles where key and path agree (1, 2)
-            val pathIndex = path[matchingLength].toInt()            // Nibble where key and path diverge (4)
-            val remainingPath = path.remainingAfter(matchingLength) // Path nibbles after divergence (5, 6)
-
-            // Branch either to the inner node or to an extension terminating in the inner node
-            val firstBranch = if (remainingPath.isEmpty()) innerNode else extension(remainingPath, innerNode)
-
-            val branchNode = if (matchingLength == key.size) {
-                // Path (1, 2, 3...) contains entire key (1, 2, 3)
-
-                // 3 -> firstBranch
-                branch(listOf(pathIndex to firstBranch), newValue)
-            } else {
-                // Path (1, 2, 3...) contains part of key (1, 2, 4, 5, 6)
-                val keyIndex = key[matchingLength].toInt()            // Nibble where key and path diverge (4)
-                val remainingKey = key.remainingAfter(matchingLength) // Key nibbles after divergence (5, 6)
-
-                // 3 -> firstBranch
-                // 4 -> leaf((5, 6), newValue)
-                branch(listOf(pathIndex to firstBranch, keyIndex to leaf(remainingKey, newValue)))
-            }
-
-            return if (matchingPath.isEmpty()) branchNode else extension(matchingPath, branchNode)
-        }
-
-        override fun get(key: NibbleArray): ByteArray {
-            val matchingLength = path.prefixMatchingLength(key)
-            if (matchingLength < path.size) {
-                return ByteArray(0) // TODO: key not found
-            }
-
-            return innerNode.get(key.dropFirst(matchingLength))
-        }
-
-        override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore =
-                if (key.startsWith(path)) {
-                    store.put(hash, encoded)
-                    innerNode.generateMerkleProof(key.dropFirst(path.size), store)
-                } else {
-                    throw IllegalArgumentException("Key is not part of the trie")
-                }
-
-        override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
-            if (key.startsWith(path)) {
-                verifyMerkleProof(
-                    innerNode.hash,
-                    key.dropFirst(path.size),
-                    expectedValue,
-                    proof
-                )
-            } else {
-                throw IllegalArgumentException("Key is not part of the trie")
-            }
-
-    }
-
-    /**
-     * Represents a BranchNode in a Patricia Trie.
-     *
-     * A BranchNode consists of an array of Node branches and a value.
-     * The encoded form is an RLP (Recursive Length Prefix) encoded list of the branches and value.
-     *
-     * @property branches The array of Nodes that the BranchNode contains.
-     * @property value The value of the BranchNode.
-     */
-    class BranchNode(
-        private val branches: Array<Node>,
-        val value: ByteArray
-    ) : Node() {
-
-        /**
-         * The RLP-encoded form of the BranchNode, which is an RLP-encoded list of the branches and value.
-         */
-        override val encoded: ByteArray
-            get() {
-                return RlpEncoder.encode(RlpList(branches.map { node ->
-                    val encodedNode = node.encoded
-                    when {
-                        node is EmptyNode -> RlpString.create(ByteArray(0))
-                        // NOTE: in the next line, if node can be a HashNode then we need to call
-                        // node.hash otherwise we can optimize and call Hash.sha3(encodedNode)
-                        encodedNode.size >= 32 -> RlpString.create(node.hash)
-                        else -> RlpString.create(encodedNode)
-                    }
-                }.plus(RlpString.create(value))))
-            }
-
-        fun getBranch(branch: Byte): Node = branches[branch.toInt()]
-
-        override fun put(key: NibbleArray, newValue: ByteArray): Node =
-            if (key.isEmpty()) branch(branches, newValue)
-            else {
-                val newBranches = Array(16) { index ->
-                    if (index == key.head.toInt()) getBranch(key.head).put(key.tail, newValue) else branches[index]
-                }
-                branch(newBranches, value)
-            }
-
-        override fun get(key: NibbleArray): ByteArray = if (key.isEmpty()) value else getBranch(key.head).get(key.tail)
-
-        override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
-                store.put(hash, encoded)
-
-                if (key.isEmpty()) {
-                    require(value.isNotEmpty()) { "Terminal branch without value" }
-                    return store
-                }
-
-                return getBranch(key.head).generateMerkleProof(key.tail, store)
-            }
-
-        override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
-            if (key.isEmpty()) {
-                value.contentEquals(expectedValue)
-            } else {
-                verifyMerkleProof(getBranch(key.head).hash, key.tail, expectedValue, proof)
-            }
-    }
-
-    /**
-     * A representation of a node in a Patricia Trie that is used to store a hash and an inner node.
-     * This class provides methods to create a new HashNode and retrieve its encoded representation.
-     *
-     * @param hash The hash of the node
-     * @param innerNode The inner node associated with this HashNode. Defaults to an EmptyNode if not provided.
-     */
-    class HashNode(override val hash: ByteArray, private val innerNode: Node) : Node() {
-        /**
-         * Returns the encoded representation of the HashNode. If the inner node is an EmptyNode,
-         * it returns the hash of the node, otherwise it returns the encoded representation of the inner node.
-         */
-        override val encoded: ByteArray get() = if (innerNode is EmptyNode) hash else innerNode.encoded
-
-        override fun put(key: NibbleArray, newValue: ByteArray): Node {
-            throw UnsupportedOperationException("Cannot put into HashNode")
-        }
-
-        override fun get(key: NibbleArray): ByteArray {
-            throw UnsupportedOperationException("Cannot get from HashNode")
-        }
-
-        override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
-            throw UnsupportedOperationException("Cannot generate Merkle proof from HashNode")
-        }
-
-        override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean {
-            throw UnsupportedOperationException("Cannot verify Merkle proof from HashNode")
-        }
-    }
-
-    /**
-     * Represents a LeafNode in a Patricia Trie.
-     *
-     * A LeafNode consists of a path (represented as a nibble array) and a value (represented as a byte array).
-     * The encoded form is an RLP (Recursive Length Prefix) encoded list of the path and value.
-     *
-     * @property path The path of the node, represented as a nibble array.
-     * @property value The value of the node, represented as a byte array.
-     */
-    class LeafNode(
-        val path: NibbleArray,
-        val value: ByteArray
-    ) : Node() {
-
-        /**
-         * The RLP-encoded form of the LeafNode, which is an RLP-encoded list of the path and value.
-         */
-        override val encoded: ByteArray
-            get() {
-                return RlpEncoder.encode(
-                    RlpList(
-                        RlpString.create(PatriciaTriePathType.LEAF.applyPrefix(path).toBytes()),
-                        RlpString.create(value)
-                    )
-                )
-            }
-
-        override fun put(key: NibbleArray, newValue: ByteArray): Node {
-            // Overwrite value if key and path match exactly
-            if (path == key) return leaf(key, newValue)
-
-            val matchingLength = path.prefixMatchingLength(key)
-
-            val branches = mutableListOf<Pair<Int, Node>>()
-
-            // If there's some path (1, 2, 3, 4) left after the match (1, 2) with key (1, 2, 5, 6)
-            if (matchingLength < path.size) {
-                // Put the current value in a branch: 3 -> leaf((4), value)
-                branches.add(path[matchingLength].toInt() to leaf(path.remainingAfter(matchingLength), value))
-            }
-
-            // If there's some key (1, 2, 5, 6) left after the match (1, 2) with path (1, 2, 3, 4)
-            if (matchingLength < key.size) {
-                // Put the new value in a branch: 5 -> ((6), newValue)
-                branches.add(key[matchingLength].toInt() to leaf(key.remainingAfter(matchingLength), newValue))
-            }
-
-            /*
-            Note implicit logic here:
-
-            * matchingLength is never more than path.size, and never more than key.size
-            * path.size and key.size are never equal, or we would have hit the exact match condition above.
-            * If matchingLength is path.size, it cannot be equal to key.size, so it must be less than key.size.
-            * If matchingLength is key.size, it cannot be equal to path.size, so it must be less than path.size
-
-             */
-            val branchNode = when (matchingLength) {
-                // Implicitly, matchingLength < key.size, so branch to newValue is in branches
-                path.size -> branch(branches, value)
-                // Implicitly, matchingLength < path.size, so branch to value is in branches
-                key.size -> branch(branches, newValue)
-                // MatchingLength < key.size && matchingLength < path.size, so both branches are present
-                else -> branch(branches)
-            }
-
-            return if (matchingLength == 0) branchNode else extension(path.takeFirst(matchingLength), branchNode)
-        }
-
-        override fun get(key: NibbleArray): ByteArray = if (key == path) value else ByteArray(0)
-
-        override fun generateMerkleProof(key: NibbleArray, store: WriteableKeyValueStore): KeyValueStore {
-            if (path == key) {
-                store.put(hash, encoded)
-                return store
-            } else {
-                throw IllegalArgumentException("Key is not part of the trie")
-            }
-        }
-
-        override fun verifyMerkleProof(key: NibbleArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
-            if (path == key) {
-                value.contentEquals(expectedValue)
-            } else {
-                throw IllegalArgumentException("Key is not part of the trie")
-            }
-    }
 }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -21,12 +21,11 @@ package com.r3.corda.interop.evm.common.trie
  * It's an ordered tree data structure used to store a dynamic set or associative array
  * where the keys are usually strings.
  */
-class PatriciaTrie {
+class PatriciaTrie(var root: Node = Node.empty) {
 
     /**
      * The root node of the Patricia Trie.
      */
-    var root: Node = Node.empty
 
     /**
      * Puts a key-value pair in the Patricia Trie.
@@ -58,6 +57,9 @@ class PatriciaTrie {
         return root.generateMerkleProof(NibbleArray.fromBytes(key), SimpleKeyValueStore())
     }
 
+    fun verifyMerkleProof(key: ByteArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
+        root.verifyMerkleProof(NibbleArray.fromBytes(key), expectedValue, proof)
+
     /**
      * Companion object that provides functionality to verify a Merkle proof.
      */
@@ -78,6 +80,7 @@ class PatriciaTrie {
             expectedValue: ByteArray,
             proof: KeyValueStore
         ): Boolean = Node.verifyMerkleProof(rootHash, NibbleArray.fromBytes(key), expectedValue, proof)
+
     }
 
 }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -60,28 +60,7 @@ class PatriciaTrie(var root: Node = EmptyNode) {
     fun verifyMerkleProof(key: ByteArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
         proof.verify(root.hash, NibbleArray.fromBytes(key), expectedValue)
 
-    /**
-     * Companion object that provides functionality to verify a Merkle proof.
-     */
-    companion object {
 
-        /**
-         * Verifies the Merkle proof for a given key and expected value.
-         *
-         * @param rootHash The root hash of the trie.
-         * @param key The key for which to verify the proof.
-         * @param expectedValue The expected value for the key.
-         * @param proof The proof to verify.
-         * @return Boolean indicating whether the proof is valid.
-         */
-        fun verifyMerkleProof(
-            rootHash: ByteArray,
-            key: ByteArray,
-            expectedValue: ByteArray,
-            proof: KeyValueStore
-        ): Boolean = proof.verify(rootHash, NibbleArray.fromBytes(key), expectedValue)
-
-    }
 
 }
 

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -21,7 +21,7 @@ package com.r3.corda.interop.evm.common.trie
  * It's an ordered tree data structure used to store a dynamic set or associative array
  * where the keys are usually strings.
  */
-class PatriciaTrie(var root: Node = Node.empty) {
+class PatriciaTrie(var root: Node = EmptyNode) {
 
     /**
      * The root node of the Patricia Trie.
@@ -58,7 +58,7 @@ class PatriciaTrie(var root: Node = Node.empty) {
     }
 
     fun verifyMerkleProof(key: ByteArray, expectedValue: ByteArray, proof: KeyValueStore): Boolean =
-        root.verifyMerkleProof(NibbleArray.fromBytes(key), expectedValue, proof)
+        proof.verify(root.hash, NibbleArray.fromBytes(key), expectedValue)
 
     /**
      * Companion object that provides functionality to verify a Merkle proof.
@@ -79,7 +79,7 @@ class PatriciaTrie(var root: Node = Node.empty) {
             key: ByteArray,
             expectedValue: ByteArray,
             proof: KeyValueStore
-        ): Boolean = Node.verifyMerkleProof(rootHash, NibbleArray.fromBytes(key), expectedValue, proof)
+        ): Boolean = proof.verify(rootHash, NibbleArray.fromBytes(key), expectedValue)
 
     }
 

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -47,7 +47,7 @@ class PatriciaTrie {
      * @return Value associated with the key as ByteArray.
      */
     fun get(key: ByteArray): ByteArray {
-        return internalGet(NibbleArray.fromBytes(key))
+        return internalGet(root, NibbleArray.fromBytes(key))
     }
 
     /**
@@ -173,11 +173,9 @@ class PatriciaTrie {
      * @param nibblesKey The key for which to get the value.
      * @return The value associated with the key, or an empty ByteArray if the key does not exist.
      */
-    private fun internalGet(nibblesKey: NibbleArray): ByteArray {
-        var node = root
-        var key = nibblesKey
+    private fun internalGet(node: Node, nibblesKey: NibbleArray): ByteArray {
+        val key = nibblesKey
 
-        while (true) {
             if (node is EmptyNode) return ByteArray(0) // TODO: key not found ?
 
             if (node is LeafNode) {
@@ -190,13 +188,8 @@ class PatriciaTrie {
             }
 
             if (node is BranchNode) {
-                if (key.isEmpty()) {
-                    return node.value // TODO: should check if the node has a value?
-                }
-
-                node = node.getBranch(key.head)
-                key = key.tail
-                continue
+                // TODO: should check if node has value?
+                return if (key.isEmpty()) node.value else internalGet(node.getBranch(key.head), key.tail)
             }
 
             if (node is ExtensionNode) {
@@ -206,13 +199,11 @@ class PatriciaTrie {
                     return ByteArray(0) // TODO: key not found
                 }
 
-                node = node.innerNode
-                key = key.dropFirst(matchingLength)
-                continue
+                return internalGet(node.innerNode, key.dropFirst(matchingLength))
             }
 
             throw IllegalArgumentException("Invalid node type")
-        }
+
     }
 }
 

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -16,8 +16,6 @@
 
 package com.r3.corda.interop.evm.common.trie
 
-import com.r3.corda.interop.evm.common.trie.Node.*
-
 /**
  * The Patricia Trie is a space-optimized version of a binary trie.
  * It's an ordered tree data structure used to store a dynamic set or associative array

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTrie.kt
@@ -57,54 +57,7 @@ class PatriciaTrie {
      * @return Merkle proof as KeyValueStore.
      */
     fun generateMerkleProof(key: ByteArray) : KeyValueStore {
-        return generateMerkleProof(root, NibbleArray.fromBytes(key), SimpleKeyValueStore())
-    }
-
-    /**
-     * Generates a Merkle proof for a given key.
-     *
-     * @param node Key as ByteArray.
-     * @param key Key as a nibbles' ByteArray.
-     * @param store A simple Key-Value that will collect the trie proofs
-     * @return Merkle proof as KeyValueStore.
-     */
-    private fun generateMerkleProof(node: Node, key: NibbleArray, store: WriteableKeyValueStore) : KeyValueStore {
-        while (true) {
-            when (node) {
-                is EmptyNode -> throw IllegalArgumentException("Key is not part of the trie")
-                is LeafNode -> {
-                    if (node.path == key) {
-                        store.put(node.hash, node.encoded)
-                        return store
-                    } else {
-                        throw IllegalArgumentException("Key is not part of the trie")
-                    }
-                }
-
-                is BranchNode -> {
-                    store.put(node.hash, node.encoded)
-
-                    if (key.isEmpty()) {
-                        require(node.value.isNotEmpty()) { "Terminal branch without value" }
-                        return store
-                    }
-
-                    val nextNibble = key.head
-                    return generateMerkleProof(node.getBranch(nextNibble), key.tail, store)
-                }
-
-                is ExtensionNode -> {
-                    if (key.startsWith(node.path)) {
-                        store.put(node.hash, node.encoded)
-                        return generateMerkleProof(node.innerNode, key.dropFirst(node.path.size), store)
-                    } else {
-                        throw IllegalArgumentException("Key is not part of the trie")
-                    }
-                }
-
-                else -> throw IllegalArgumentException("Invalid node type")
-            }
-        }
+        return root.generateMerkleProof(NibbleArray.fromBytes(key), SimpleKeyValueStore())
     }
 
     /**

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTriePathPrefix.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTriePathPrefix.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.r3.corda.interop.evm.common.trie
 
 enum class PatriciaTriePathPrefix(vararg  nibbleValues: Byte) {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTriePathType.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/main/kotlin/com/r3/corda/interop/evm/common/trie/PatriciaTriePathType.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023, R3 LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.r3.corda.interop.evm.common.trie
 
 import com.r3.corda.interop.evm.common.trie.PatriciaTriePathPrefix.*

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Proof.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Proof.kt
@@ -134,12 +134,7 @@ class ProofTests {
 
         assertTrue(entries.all { (key, value) ->
             val proof = trie.generateMerkleProof(key)
-
-            PatriciaTrie.verifyMerkleProof(
-                rootHash = trie.root.hash,
-                key = key,
-                expectedValue = value,
-                proof = proof)
+            trie.verifyMerkleProof(key, value, proof)
         })
     }
 }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/TestBuilders.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/TestBuilders.kt
@@ -6,7 +6,7 @@ class LeafNodeBuilder(val nibbles: NibbleArray) {
 }
 
 class ExtensionNodeBuilder(val pathNibbles: NibbleArray) {
-    fun empty() = Node.extension(pathNibbles, Node.EmptyNode)
+    fun empty() = Node.extension(pathNibbles, EmptyNode)
     fun withInner(inner: Node) = Node.extension(pathNibbles, inner)
     fun toBranches(vararg branches: Pair<Int, Node>) =
         InnerBranchNodeBuilder(this, branchNode(*branches))

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/TestBuilders.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/TestBuilders.kt
@@ -1,13 +1,13 @@
 package com.r3.corda.interop.evm.common.trie
 
 class LeafNodeBuilder(val nibbles: NibbleArray) {
-    fun withValue(stringValue: String) = Node.leaf(nibbles, stringValue.toByteArray())
-    fun withValue(vararg byteArray: Byte) = Node.leaf(nibbles, byteArray)
+    fun withValue(stringValue: String) = LeafNode(nibbles, stringValue.toByteArray())
+    fun withValue(vararg byteArray: Byte) = LeafNode(nibbles, byteArray)
 }
 
 class ExtensionNodeBuilder(val pathNibbles: NibbleArray) {
-    fun empty() = Node.extension(pathNibbles, EmptyNode)
-    fun withInner(inner: Node) = Node.extension(pathNibbles, inner)
+    fun empty() = ExtensionNode(pathNibbles, EmptyNode)
+    fun withInner(inner: Node) = ExtensionNode(pathNibbles, inner)
     fun toBranches(vararg branches: Pair<Int, Node>) =
         InnerBranchNodeBuilder(this, branchNode(*branches))
 }
@@ -21,9 +21,9 @@ class BranchNodeBuilder(val branches: List<Pair<Int, Node>>) {
 
     fun withValue(value: String): Node = withValue(value.toByteArray())
 
-    fun withValue(value: ByteArray): Node = Node.branch(branches, value)
+    fun withValue(value: ByteArray): Node = BranchNode.from(branches, value)
 
-    fun empty() = Node.branch(branches)
+    fun empty() = BranchNode.from(branches)
 }
 
 fun trie(build: TrieBuilder.() -> Unit): PatriciaTrie {

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Trie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Trie.kt
@@ -27,7 +27,7 @@ class TrieTests {
 
     @Test
     fun testEmptyNodeHashCalculation() {
-        val emptyNode = Node.EmptyNode
+        val emptyNode = EmptyNode
         val expectedHash = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
 
         assertEquals(expectedHash, Numeric.toHexString(emptyNode.hash))
@@ -70,7 +70,7 @@ class TrieTests {
         val trie = trie { }
         val expectedHash = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
 
-        assert(trie.root is Node.EmptyNode)
+        assert(trie.root is EmptyNode)
         assertEquals(expectedHash, Numeric.toHexString(trie.root.hash))
     }
 
@@ -88,7 +88,7 @@ class TrieTests {
         val leaf = Node.leaf(key, value)
         val expectedHash = "0x2fc0c91eb10b756afb03c8ceafc121c9c2f4eb47b6ef974ba808f8b46067a6d0"
 
-        assertTrue(trie.root is Node.LeafNode)
+        assertTrue(trie.root is LeafNode)
         assertArrayEquals(leaf.hash, trie.root.hash)
         assertEquals(expectedHash, Numeric.toHexString(trie.root.hash))
     }

--- a/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Trie.kt
+++ b/src/r3/atomic-swap/corda/evm-interop-common/src/test/kotlin/com/r3/corda/interop/evm/common/trie/Trie.kt
@@ -85,7 +85,7 @@ class TrieTests {
 
         trie.put(key, value)
 
-        val leaf = Node.leaf(key, value)
+        val leaf = LeafNode(NibbleArray.fromBytes(key), value)
         val expectedHash = "0x2fc0c91eb10b756afb03c8ceafc121c9c2f4eb47b6ef974ba808f8b46067a6d0"
 
         assertTrue(trie.root is LeafNode)


### PR DESCRIPTION
This PR makes the `put`, `get`, `generateMerkleProof` and `verifyMerkleProof` functions fully recursive, and delegates the implementation to each node type's class, removing a lot of pattern-matching code. It also adds some inline comments around some of the nastier details of updating the trie, and missing copyright notices on some file headers.