### PR TITLE
Fix build issue regarding Gradle repository declarations

### DIFF
--- a/src/r3/atomic-swap/corda/build.gradle
+++ b/src/r3/atomic-swap/corda/build.gradle
@@ -23,7 +23,7 @@ buildscript { //properties that you need to build the project
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url 'https://software.r3.com/artifactory/corda-releases' }
+        maven { url 'https://download.corda.net/maven/corda-releases' }
     }
 
     dependencies {
@@ -45,7 +45,7 @@ allprojects { //Properties that you need to compile your project (The applicatio
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url 'https://software.r3.com/artifactory/corda' }
+        maven { url 'https://download.corda.net/maven/corda' }
         maven { url 'https://jitpack.io' }
     }
 

--- a/src/r3/atomic-swap/corda/build.gradle
+++ b/src/r3/atomic-swap/corda/build.gradle
@@ -45,7 +45,7 @@ allprojects { //Properties that you need to compile your project (The applicatio
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url 'https://download.corda.net/maven/corda' }
+        maven { url 'https://download.corda.net/maven/corda-releases' }
         maven { url 'https://jitpack.io' }
     }
 

--- a/src/r3/atomic-swap/corda/repositories.gradle
+++ b/src/r3/atomic-swap/corda/repositories.gradle
@@ -2,6 +2,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://jitpack.io' }
-    maven { url 'https://software.r3.com/artifactory/corda' }
+    maven { url 'https://download.corda.net/maven/corda' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }

--- a/src/r3/atomic-swap/corda/repositories.gradle
+++ b/src/r3/atomic-swap/corda/repositories.gradle
@@ -2,6 +2,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://jitpack.io' }
-    maven { url 'https://download.corda.net/maven/corda' }
+    maven { url 'https://download.corda.net/maven/corda-dependencies' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }


### PR DESCRIPTION
**Overview:**
Due to a change in R3s Artifactory usage, a number of repository declarations need to be updated as these locations are no longer available without authentication. However, an alternative public mirror is now available. 

**Changes:**
All references to `https://software.r3.com/artifactory`  changed to `https://download.corda.net/maven`. This is a public mirror of the previously available repository with access to the same artifacts.

`repositories.gradle` - updated to reference `https://download.corda.net/maven/corda-dependencies`, rather than the previous `*/corda` repository, the reason for this is `corda` is a virtual repository in artifactory consisting of several others, this concept of a virtual repository does not exist in the public mirror, so we explicitly declare the needed repository.

Local compilation is confirmed to be working as expected with this change

